### PR TITLE
upgrade wc-compiler 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34322,9 +34322,9 @@
       }
     },
     "node_modules/wc-compiler": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.2.1.tgz",
-      "integrity": "sha512-s5tLEzFbVYyad0LG4lzzR65iSr6fcTgs53wvGyllsFVt68K4qVMGOANj+LgsCjuMz/JrxkqAiql+YAl8+vV5Ow==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.2.2.tgz",
+      "integrity": "sha512-Q2HRjOL9/MhiccDMUsm0OPfhrYW37tH1ivayd27mY/WoLVoq73PkXZkG1RU8Vc+wTkR4OYZ2iD1UNJnWUx8slQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -60450,9 +60450,9 @@
       }
     },
     "wc-compiler": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.2.1.tgz",
-      "integrity": "sha512-s5tLEzFbVYyad0LG4lzzR65iSr6fcTgs53wvGyllsFVt68K4qVMGOANj+LgsCjuMz/JrxkqAiql+YAl8+vV5Ow==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.2.2.tgz",
+      "integrity": "sha512-Q2HRjOL9/MhiccDMUsm0OPfhrYW37tH1ivayd27mY/WoLVoq73PkXZkG1RU8Vc+wTkR4OYZ2iD1UNJnWUx8slQ==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",


### PR DESCRIPTION
Better support for bare specifiers + Node >=16 for WCC
https://github.com/thescientist13/wcc/releases/tag/0.2.2